### PR TITLE
fix: missing parameter admin

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvi
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Route;
+use App\Models\Product;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -24,6 +25,10 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        parent::boot();
+
+        Route::model('admin', Product::class);
+
         RateLimiter::for('api', function (Request $request) {
             return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
         });

--- a/resources/views/admin/edit.blade.php
+++ b/resources/views/admin/edit.blade.php
@@ -12,7 +12,7 @@
 </div>
 @endif
 
-<form action="{{ route('admin.update', $product) }}" method="POST">
+<form action="{{ route('admin.update', $product->id) }}" method="POST">
     @csrf
     @method('PUT')
     <div>


### PR DESCRIPTION
It showed error message that it was missing parameter admin and I couldn't get to the edit page. Turns out I need to manually bind the {admin} parameter to Product model